### PR TITLE
fix: envtest

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -314,6 +314,21 @@ func createConfigMap(name string, namespace string, data map[string]string) {
 	Expect(k8sClient.Create(ctx, &configMap)).Should(Succeed())
 }
 
+func deleteConfigMap(name string, namespace string) {
+	configMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	Expect(k8sClient.Delete(ctx, &configMap)).Should(Succeed())
+}
+
 func createSecret(name, namespace string) {
 	secret := corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -324,7 +339,6 @@ func createSecret(name, namespace string) {
 			Name:      name,
 			Namespace: namespace,
 		},
-
 	}
 	Expect(k8sClient.Create(ctx, &secret)).Should(Succeed())
 }


### PR DESCRIPTION
The test was failing on [this line](https://github.com/redhat-appstudio/build-service/pull/29/files#diff-d35691b34d03fffedc031a0a69d9a4505fb380f307010df7c8937715928c73a8R202)
```
                Message: "secrets \"git-secret\" already exists",
                Reason: "AlreadyExists",
                Details: {Name: "git-secret", Group: "", Kind: "secrets", UID: "", Causes: nil, RetryAfterSeconds: 0},
                Code: 409,
```
and a similar issue regarding existing configmap ([this line](https://github.com/redhat-appstudio/build-service/pull/29/files#diff-d35691b34d03fffedc031a0a69d9a4505fb380f307010df7c8937715928c73a8R206))